### PR TITLE
[Refactor] 로그인 서비스 역할 분리 및 불필요한 프린트 삭제

### DIFF
--- a/src/main/java/org/example/buyingserver/common/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/org/example/buyingserver/common/auth/OAuth2SuccessHandler.java
@@ -3,10 +3,10 @@ package org.example.buyingserver.common.auth;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.buyingserver.member.domain.Member;
-import org.example.buyingserver.member.repository.MemberRepository;
+import org.example.buyingserver.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -17,64 +17,50 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Value("${oauth2.frontend.redirect-uri}")
     private String frontendRedirectUri;
 
     @Override
-    @Transactional
-    public void onAuthenticationSuccess(HttpServletRequest request,
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
             HttpServletResponse response,
-            Authentication authentication)
-            throws IOException, ServletException {
+            Authentication authentication
+    ) throws IOException, ServletException {
 
-        // 1. OAuth2 로그인 완료된 사용자 정보 추출
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
-        System.out.println("[DEBUG] : 로그인 완료 후 사용자 정보 추출 email " + email);
+
+        log.debug("OAuth2 SuccessHandler - email={}", email);
 
         if (email == null) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "이메일 정보를 가져올 수 없습니다.");
             return;
         }
 
-        // 2. DB에서 회원 찾기
-        Member member = memberRepository.findByEmail(email).orElse(null);
+        //회원 조회 + 회원 생성 (비즈니스 로직을 서비스로 이관)
+        Member member = memberService.findOrCreateOAuthMember(oAuth2User);
 
-        // 회원이 없으면 생성 (CustomOAuth2UserService에서 생성되지 않은 경우 대비)
-        if (member == null) {
-            System.out.println("[DEBUG] OAuth2SuccessHandler - 회원이 없어서 생성 시작: " + email);
-            String name = oAuth2User.getAttribute("name");
-            String socialId = oAuth2User.getAttribute("sub"); // Google의 userNameAttributeName
+        log.debug("OAuth2 SuccessHandler - 로그인 사용자 ID={}", member.getId());
 
-            member = Member.oauthCreate(
-                    email,
-                    name != null ? name : email.split("@")[0],
-                    socialId,
-                    org.example.buyingserver.member.domain.SocialType.GOOGLE);
-            member = memberRepository.save(member);
-            System.out.println("[DEBUG] OAuth2SuccessHandler - 회원 생성 완료: " + email + ", ID: " + member.getId());
-        } else {
-            System.out.println("[DEBUG] OAuth2SuccessHandler - 기존 회원 발견: " + email + ", ID: " + member.getId());
-        }
-
-        // 3. JWT 생성
+        // JWT 생성
         String accessToken = jwtTokenProvider.createToken(email);
 
-        // 4. 프론트엔드로 리다이렉트하면서 토큰 전달
+        // 프론트로 리다이렉트
         String encodedToken = URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
         String redirectUrl = String.format("%s?token=%s&memberId=%d",
                 frontendRedirectUri,
                 encodedToken,
                 member.getId());
 
-        System.out.println("[DEBUG] OAuth2SuccessHandler - 프론트엔드로 리다이렉트: " + redirectUrl);
+        log.debug("OAuth2 SuccessHandler - redirectUrl={}", redirectUrl);
         response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/org/example/buyingserver/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/buyingserver/common/config/SecurityConfig.java
@@ -29,7 +29,6 @@ public class SecurityConfig {
 
     private final JwtTokenFilter jwtTokenFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
-    private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final CustomAccessDeniedHandler accessDeniedHandler;
 
@@ -40,7 +39,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, OAuth2SuccessHandler oAuth2SuccessHandler) throws Exception {
 
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
@@ -73,7 +72,6 @@ public class SecurityConfig {
                         )
                         .successHandler(oAuth2SuccessHandler)
                         .failureHandler((request, response, e) -> {
-                            System.out.println("[DEBUG] : OAuth2 로그인 실패 " + e.getMessage());
 
                             GlobalErrorCode error = GlobalErrorCode.UNAUTHORIZED;
 

--- a/src/main/java/org/example/buyingserver/member/domain/SocialType.java
+++ b/src/main/java/org/example/buyingserver/member/domain/SocialType.java
@@ -1,5 +1,10 @@
 package org.example.buyingserver.member.domain;
 
 public enum SocialType {
-    GOOGLE,KAKAO
+    GOOGLE,KAKAO;
+
+    public static SocialType from(String type) {
+        return SocialType.valueOf(type.toUpperCase());
+    }
 }
+

--- a/src/main/java/org/example/buyingserver/member/domain/SocialType.java
+++ b/src/main/java/org/example/buyingserver/member/domain/SocialType.java
@@ -1,7 +1,7 @@
 package org.example.buyingserver.member.domain;
 
 public enum SocialType {
-    GOOGLE,KAKAO;
+    GOOGLE,KAKAO, UNKNOWN;
 
     public static SocialType from(String type) {
         return SocialType.valueOf(type.toUpperCase());

--- a/src/main/java/org/example/buyingserver/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/example/buyingserver/member/service/CustomOAuth2UserService.java
@@ -1,67 +1,35 @@
 package org.example.buyingserver.member.service;
 
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.example.buyingserver.member.domain.Member;
+import lombok.extern.slf4j.Slf4j;
 import org.example.buyingserver.member.domain.SocialType;
-import org.example.buyingserver.member.repository.MemberRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-import java.util.Optional;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    private final MemberRepository memberRepository;
-    private final EntityManager entityManager;
-
     @Override
-    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
-        System.out.println("[DEBUG] CustomOAuth2UserService.loadUser 실행 시작");
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // google, kakao
+
         String userNameAttributeName = userRequest
                 .getClientRegistration()
                 .getProviderDetails()
                 .getUserInfoEndpoint()
                 .getUserNameAttributeName();
 
-        String email = oAuth2User.getAttribute("email");
-        String name = oAuth2User.getAttribute("name");
-        String socialId = oAuth2User.getAttribute(userNameAttributeName);
+        SocialType socialType = SocialType.from(registrationId);
 
-        System.out.println(
-                "[DEBUG] CustomOAuth2UserService - email: " + email + ", name: " + name + ", socialId: " + socialId);
+        log.debug("OAuth Provider = {}, userNameAttributeKey = {}", socialType, userNameAttributeName);
+        log.debug("OAuth Attributes = {}", oAuth2User.getAttributes());
 
-        Optional<Member> existingMember = memberRepository.findByEmail(email);
-        if (existingMember.isPresent()) {
-            System.out.println("[DEBUG] CustomOAuth2UserService - 기존 회원 발견: " + email);
-            return new DefaultOAuth2User(
-                    Collections.emptyList(),
-                    oAuth2User.getAttributes(),
-                    userNameAttributeName);
-        }
-
-        System.out.println("[DEBUG] CustomOAuth2UserService - 새 회원 생성 시작: " + email);
-        Member newMember = Member.oauthCreate(email, name, socialId, SocialType.GOOGLE);
-        Member savedMember = memberRepository.save(newMember);
-        // 트랜잭션이 커밋되기 전에 DB에 반영되도록 flush
-        entityManager.flush();
-        System.out.println(
-                "[DEBUG] CustomOAuth2UserService - 회원 생성 완료 및 flush: " + email + ", ID: " + savedMember.getId());
-
-        return new DefaultOAuth2User(
-                Collections.emptyList(),
-                oAuth2User.getAttributes(),
-                userNameAttributeName);
+        return oAuth2User;
     }
 }

--- a/src/main/java/org/example/buyingserver/member/service/MemberService.java
+++ b/src/main/java/org/example/buyingserver/member/service/MemberService.java
@@ -80,8 +80,10 @@ public class MemberService {
     public Member findOrCreateOAuthMember(OAuth2User oAuth2User) {
         String email = oAuth2User.getAttribute("email");
         String name = oAuth2User.getAttribute("name");
-        String socialId = extractSocialId(oAuth2User);   // ← 분리된 메서드 사용
+        String socialId = extractSocialId(oAuth2User);
         String nickname = (name != null) ? name : email.split("@")[0];
+        SocialType socialType = detectSocialType(oAuth2User);
+
 
         return memberRepository.findByEmail(email)
                 .orElseGet(() -> {
@@ -89,7 +91,7 @@ public class MemberService {
                             email,
                             nickname,
                             socialId,
-                            SocialType.GOOGLE
+                            socialType
                     );
                     return memberRepository.save(newMember);
                 });
@@ -108,5 +110,16 @@ public class MemberService {
             socialId = oAuth2User.getAttribute("id");
         }
         return socialId;
+    }
+
+    private SocialType detectSocialType(OAuth2User oAuth2User) {
+        if (oAuth2User.getAttribute("sub") != null) {
+            return SocialType.GOOGLE;
+        }
+        if (oAuth2User.getAttribute("id") != null) {
+            return SocialType.KAKAO;
+        }
+        return SocialType.UNKNOWN;
+
     }
 }

--- a/src/main/java/org/example/buyingserver/member/service/MemberService.java
+++ b/src/main/java/org/example/buyingserver/member/service/MemberService.java
@@ -3,11 +3,13 @@ package org.example.buyingserver.member.service;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.example.buyingserver.common.auth.JwtTokenProvider;
+import org.example.buyingserver.member.domain.SocialType;
 import org.example.buyingserver.member.dto.*;
 import org.example.buyingserver.member.domain.Member;
 import org.example.buyingserver.member.exception.*;
 import org.example.buyingserver.member.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,10 +76,37 @@ public class MemberService {
         return new MemberProfileDto(member.getEmail(), member.getNickname());
     }
 
+    @Transactional
+    public Member findOrCreateOAuthMember(OAuth2User oAuth2User) {
+        String email = oAuth2User.getAttribute("email");
+        String name = oAuth2User.getAttribute("name");
+        String socialId = extractSocialId(oAuth2User);   // ← 분리된 메서드 사용
+        String nickname = (name != null) ? name : email.split("@")[0];
+
+        return memberRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    Member newMember = Member.oauthCreate(
+                            email,
+                            nickname,
+                            socialId,
+                            SocialType.GOOGLE
+                    );
+                    return memberRepository.save(newMember);
+                });
+    }
+
 
     private void validateDuplicateEmail(String email) {
         if (memberRepository.findByEmail(email).isPresent()) {
             throw new DuplicateEmailException();
         }
+    }
+
+    private String extractSocialId(OAuth2User oAuth2User) {
+        String socialId = oAuth2User.getAttribute("sub"); // Google
+        if (socialId == null) {
+            socialId = oAuth2User.getAttribute("id");
+        }
+        return socialId;
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
피드백 주신 로그인관련 역할 로직 분리하였습니다.
print메서드를 삭제하였습니다.

## 🚀 Description
로그인·소셜 로그인 역할 분리 리팩토링:
OAuth2SuccessHandler 내부에서 처리하던
회원 조회 또는 생성 로직을 MemberService 로 완전히 이관

Google: sub Kakao: id
→ ID 규칙에 따라 provider 자동 판별하도록 구현
→ SocialType 자동 결정 (GOOGLE / KAKAO)

MemberService.findOrCreateOAuthMember() 를 통해 일관되게 처리되도록 변경

## 📸 Screenshot
-
## 📢 Notes

sub 아이디로만 분리하여 구글인지 카카오로그인인지 판단하는 것에서 많이 막혔습니다.
현재는 구글만 로그인으로 사용할 예정이라 .getAttribute 만으로 판단하지만
확장을 생각하면 수정해야할 것 같습니다..